### PR TITLE
Fixed CVE typo for CVE-2020-11911

### DIFF
--- a/vu-257161/vu-257161.rules
+++ b/vu-257161/vu-257161.rules
@@ -11,4 +11,4 @@ alert dns any any -> any any (msg:"VU#257161:CVE-2020-11901 DNS malformed respon
 #uses ICMPv4 to report a parameter problem in a crafted packet X (IPv4 + ICMPv4 type=param‑problem + X),
 alert icmp any any -> any any (msg:"VU#257161:CVE-2020-11902 ICMPv4 parameter problem with tunnel inside"; itype:12; sid:1372257161; rev:1;)
 alert icmp any any -> any any (msg:"VU#257161:CVE-2020-CVE‑2020‑11910 anomalous ICMPv4 type 3,code 4 Path MTU Discovery"; itype:3; icode:4; sid:1373257161; rev:1;)
-alert icmp any any -> any any (msg:"VU#257161:CVE-2020-CVE‑2020‑1191 anomalous ICMPv4 Address Mask Reply message (type 18, code 0)"; itype:18; icode:0; sid:1374257161; rev:1;)
+alert icmp any any -> any any (msg:"VU#257161:CVE-2020-CVE‑2020‑11911 anomalous ICMPv4 Address Mask Reply message (type 18, code 0)"; itype:18; icode:0; sid:1374257161; rev:1;)


### PR DESCRIPTION
Just wanted to fix up a CVE cross-reference (feel free to ignore this request if you decide to fix it on your own, no big deal).